### PR TITLE
ignore query params when comparing urls

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -27,7 +27,7 @@ function create (options) {
 
 
   function handler (req, res, callback) {
-    if (req.url !== options.path)
+    if (req.url.split('?').shift() !== options.path)
       return callback()
 
     function hasError (msg) {

--- a/test.js
+++ b/test.js
@@ -87,6 +87,11 @@ test('handler accepts valid urls', function (t) {
     t.fail(false, 'should not call')
   })
 
+  h(mkReq('/some/url?test=param'), mkRes(), function (err) {
+    t.error(err)
+    t.fail(false, 'should not call')
+  })
+
   setTimeout(t.ok.bind(t, true, 'done'))
 })
 


### PR DESCRIPTION
this still doesn't handle things like `/some/url/?blah=1` (note the trailing `/`), but it does allow me to continue using this module!
