### PR TITLE
Add event whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ github-webhook-handler exports a single function, use this function to *create* 
 
  * `"path"`: the complete case sensitive path/route to match when looking at `req.url` for incoming requests. Any request not matching this path will cause the callback function to the handler to be called (sometimes called the `next` handler).
  * `"secret"`: this is a hash key used for creating the SHA-1 HMAC signature of the JSON blob sent by GitHub. You should register the same secret key with GitHub. Any request not delivering a `X-Hub-Signature` that matches the signature generated using this key against the blob will be rejected and cause an `'error'` event (also the callback will be called with an `Error` object).
+ * `"events"`: an optional array of whitelisted event types (see: *events.json*). If defined, any incoming request whose `X-Github-Event` can't be found in the whitelist will be rejected. If only a single event type is acceptable, this option can also be a string.
 
 The resulting **handler** function acts like a common "middleware" handler that you can insert into a processing chain. It takes `request`, `response`, and `callback` arguments. The `callback` is not called if the request is successfully handled, otherwise it is called either with an `Error` or no arguments.
 

--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -19,6 +19,14 @@ function create (options) {
   if (typeof options.secret != 'string')
     throw new TypeError('must provide a \'secret\' option')
 
+  var events
+
+  if (typeof options.events == 'string' && options.events != '*')
+    events = [ options.events ]
+
+  else if (Array.isArray(options.events) && options.events.indexOf('*') == -1)
+    events = options.events
+
   // make it an EventEmitter, sort of
   handler.__proto__ = EventEmitter.prototype
   EventEmitter.call(handler)
@@ -52,6 +60,9 @@ function create (options) {
 
     if (!id)
       return hasError('No X-Github-Delivery found on request')
+
+    if (events && events.indexOf(event) == -1)
+      return hasError('X-Github-Event is not acceptable')
 
     req.pipe(bl(function (err, data) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bl": "~0.8.0"
   },
   "devDependencies": {
+    "run-series": "~1.0.2",
     "tape": "~2.12.3",
     "through2": "~0.4.1"
   }


### PR DESCRIPTION
Hey Rod, nice module!

I've added a non-breaking feature whereby you can specify a whitelist of events you’d like to handle. Obviously you could just avoid attaching listeners for events you’re not interested in, but I figured rejecting those requests before reading their bodies into memory was a nicer way to handle things.

I've tried my best to maintain the same code style, but let me know if anything’s wrong. :)
