### PR TITLE
Passes the host information to the event listener.

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -76,6 +76,8 @@ function create (options) {
           event   : event
         , id      : id
         , payload : obj
+        , protocol: req.protocol
+        , host    : req.get('host')
         , url     : req.url
       }
 


### PR DESCRIPTION
# What?
A small change that passes a couple of extra properties (host information: protocol, hostname and url).

# Why?
Once inside the event listener obtaining this information is very cumbersome. These extra properties could be useful when updating the status of a specific pull request and adding a custom target-url (e.g. a page which displays some more results and is hosted on the same server).