### PR TITLE
Constant-time comparison for hook signature (#12)

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events').EventEmitter
     , inherits     = require('util').inherits
     , crypto       = require('crypto')
     , bl           = require('bl')
+    , bufferEq     = require('buffer-equal-constant-time')
 
 
 function signBlob (key, blob) {
@@ -59,8 +60,9 @@ function create (options) {
       }
 
       var obj
+      var computedSig = new Buffer(signBlob(options.secret, data))
 
-      if (sig !== signBlob(options.secret, data))
+      if (!bufferEq(new Buffer(sig), computedSig))
         return hasError('X-Hub-Signature does not match blob signature')
 
       try {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bl": "~0.9.4"
+    "bl": "~0.9.4",
+    "buffer-equal-constant-time": "~1.0.1"
   },
   "devDependencies": {
     "tape": "~2.12.3",


### PR DESCRIPTION
Using a straightforward boolean equality check for the hook signature opens a small vector for timing attacks; forcing constant-time comparison closes it up.