### PR TITLE
allow emit override

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ github-webhook-handler exports a single function, use this function to *create* 
 
  * `"path"`: the complete case sensitive path/route to match when looking at `req.url` for incoming requests. Any request not matching this path will cause the callback function to the handler to be called (sometimes called the `next` handler).
  * `"secret"`: this is a hash key used for creating the SHA-1 HMAC signature of the JSON blob sent by GitHub. You should register the same secret key with GitHub. Any request not delivering a `X-Hub-Signature` that matches the signature generated using this key against the blob will be rejected and cause an `'error'` event (also the callback will be called with an `Error` object).
+ * `"emit"`: an *optional* `function(headers, data)` you can specify to override the default `handler.emit()`s.
 
 The resulting **handler** function acts like a common "middleware" handler that you can insert into a processing chain. It takes `request`, `response`, and `callback` arguments. The `callback` is not called if the request is successfully handled, otherwise it is called either with an `Error` or no arguments.
 

--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -72,6 +72,9 @@ function create (options) {
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end('{"ok":true}')
 
+      if (options.emit && typeof options.emit === 'function')
+        return options.emit(req.headers, obj)
+
       var emitData = {
           event   : event
         , id      : id


### PR DESCRIPTION
I want to customize the data that is emitted.

Example:
```js
var handler = require('github-webhook-handler')({
  path: '/github',
  secret: 'hush-hush',
  emit: (headers, data)=> {
    data.custom = "I'm special";
    handler.emit(headers['x-github-event'], data);
  }
});
```