### PR TITLE
Removed JSON header to make it more flexible

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -81,8 +81,7 @@ function create (options) {
       } catch (e) {
         return hasError(e)
       }
-
-      res.writeHead(200, { 'content-type': 'application/json' })
+      
       res.end('{"ok":true}')
 
       var emitData = {


### PR DESCRIPTION
Great tool, I just had to remove the addition of a JSON header in my implementation to prevent adding a header after sending the request. Just a thought!
