### PR TITLE
Only call webhook for POST requests

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -36,7 +36,7 @@ function create (options) {
 
 
   function handler (req, res, callback) {
-    if (req.url.split('?').shift() !== options.path)
+    if (req.url.split('?').shift() !== options.path || req.method !== 'POST')
       return callback()
 
     function hasError (msg) {

--- a/test.js
+++ b/test.js
@@ -11,8 +11,9 @@ function signBlob (key, blob) {
 }
 
 
-function mkReq (url) {
+function mkReq (url, method) {
   var req = through2()
+  req.method = method || 'POST'
   req.url = url
   req.headers = {
       'x-hub-signature'   : 'bogus'
@@ -76,6 +77,22 @@ test('handler ignores invalid urls', function (t) {
   })
 })
 
+test('handler ingores non-POST requests', function (t) {
+  var options = { path: '/some/url', secret: 'bogus' }
+    , h       = handler(options)
+
+  t.plan(4)
+
+  h(mkReq('/some/url', 'GET'), mkRes(), function (err) {
+    t.error(err)
+    t.ok(true, 'request was ignored')
+  })
+
+  h(mkReq('/some/url?test=param', 'GET'), mkRes(), function (err) {
+    t.error(err)
+    t.ok(true, 'request was ignored')
+  })
+})
 
 test('handler accepts valid urls', function (t) {
   var options = { path: '/some/url', secret: 'bogus' }


### PR DESCRIPTION
From the [GitHub webhook docs](https://developer.github.com/webhooks/)

> When one of those events is triggered, we'll send a HTTP **POST** payload to the webhook's configured URL.

Currently this handler fails if you try to respond to the same URL with different methods. This PR updates it to pass the request on if it is not a `POST`.