### PR TITLE
Do not emit '*' as an event

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -95,7 +95,6 @@ function create (options) {
       }
 
       handler.emit(event, emitData)
-      handler.emit('*', emitData)
     }))
   }
 }


### PR DESCRIPTION
As we already handled '*' as a special event in `github-webhook`.

This potentially fixes "command executed twice" (https://github.com/rvagg/github-webhook/issues/3).