### PR TITLE
change Buffer.from() to new Buffer()

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -37,7 +37,8 @@ function create (options) {
   }
 
   function verify (signature, data) {
-    return bufferEq(Buffer.from(signature), Buffer.from(sign(data)))
+    //return bufferEq(Buffer.from(signature), Buffer.from(sign(data)))
+    return bufferEq(new Buffer(signature), new Buffer(sign(data)))
   }
 
   function handler (req, res, callback) {


### PR DESCRIPTION
Added in: v5.10.0
array `<Array>`
Allocates a new `Buffer` using an `array` of octets.

Example:
```
// Creates a new Buffer containing UTF-8 bytes of the string 'buffer'
const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
```
A TypeError will be thrown if array is not an Array.