### PR TITLE
feat: allow optional parameter path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# IDE
+.vscode

--- a/github-webhook-handler.d.ts
+++ b/github-webhook-handler.d.ts
@@ -4,7 +4,7 @@ import { IncomingMessage, ServerResponse } from "http";
 import { EventEmitter } from "events";
 
 interface CreateHandlerOptions {
-    path: string;
+    path?: string;
     secret: string;
     events?: string | string[];
 }

--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -8,7 +8,7 @@ function create (options) {
   if (typeof options != 'object')
     throw new TypeError('must provide an options object')
 
-  if (typeof options.path != 'string')
+  if (options.path && typeof options.path != 'string')
     throw new TypeError('must provide a \'path\' option')
 
   if (typeof options.secret != 'string')
@@ -41,7 +41,7 @@ function create (options) {
   }
 
   function handler (req, res, callback) {
-    if (req.url.split('?').shift() !== options.path || req.method !== 'POST')
+    if (options.path && req.url.split('?').shift() !== options.path || req.method !== 'POST')
       return callback()
 
     function hasError (msg) {

--- a/test.js
+++ b/test.js
@@ -41,13 +41,11 @@ function mkRes () {
 
 
 test('handler without full options throws', function (t) {
-  t.plan(4)
+  t.plan(3)
 
   t.equal(typeof handler, 'function', 'handler exports a function')
 
   t.throws(handler, /must provide an options object/, 'throws if no options')
-
-  t.throws(handler.bind(null, {}), /must provide a 'path' option/, 'throws if no path option')
 
   t.throws(handler.bind(null, { path: '/' }), /must provide a 'secret' option/, 'throws if no secret option')
 })


### PR DESCRIPTION
I encountered some problems when using this npm plugin.

I don't want to use the path parameter in the plugin, because I want to judge this parameter myself and distribute it to different methods. 

I have two sites. If a different hook request is detected, go to a different directory for git pull. Like this

``` js
const http = require('http')
const path = require('path')
const exec = require('child_process').exec
const createHandler = require('github-webhook-handler')

const root = path.join(__dirname, '../')

const port = 3000
const secret = 'xxxxxx'
const pathTable = {
  blog: { path: 'blog.mutoe.com', branch: 'master' },
  pic: { path: 'pic.mutoe.com', branch: 'gh-pages' },
}

const handler = createHandler({ secret })
let repo

http.createServer((req, res) => {
  repo = req.url.match(/^\/(\S+)/)[1]
  if (!pathTable[repo]) {
    res.statusCode = 404
    res.end('invalid repositry path')
  } else {
    handler(req, res, err => {
      res.statusCode = 404
      res.end('no such loaction')
    })
  }
}).listen(port)

handler.on('error', err => {
  console.error(`Error: ${err.message}`)
})

handler.on('push', event => {
  console.log(
    'Received a push event for %s to %s',
    repo,
    event.payload.repository.name,
    event.payload.ref
  )

  let commands = [
    `cd ${root + pathTable[repo].path}`, 
    'git pull',
  ].join(' && ')

  exec(commands, (err, out, code) => {
    if (err) {
      console.error(`exec error: ${err}`)
      return
    }
    console.log(`stderr: ${err}`)
    console.log(`stdout: ${out}`)
    console.log(`code: ${code}`)

    console.log(`Successfully pull code from ${event.payload.repository.name} to ./${pathTable[repo].path}`
    )
  })
})

console.log(`deploy server on listen in ${port}...`)

```

This code is running normally as I expected. So I submitted this PR. If you think it is okay, can you submit it to this repository?

-----
via Google Translate
