### PR TITLE
Removes buffer-equal-constant-time dependency

### DIFF
--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -2,7 +2,6 @@ const EventEmitter = require('events').EventEmitter
     , inherits     = require('util').inherits
     , crypto       = require('crypto')
     , bl           = require('bl')
-    , bufferEq     = require('buffer-equal-constant-time')
 
 function create (options) {
   if (typeof options != 'object')
@@ -37,7 +36,7 @@ function create (options) {
   }
 
   function verify (signature, data) {
-    return bufferEq(Buffer.from(signature), Buffer.from(sign(data)))
+    return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(sign(data)))
   }
 
   function handler (req, res, callback) {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bl": "~1.1.2",
-    "buffer-equal-constant-time": "~1.0.1"
+    "bl": "~1.1.2"
   },
   "devDependencies": {
     "@types/node": "*",


### PR DESCRIPTION
Removes external library in favour of built-in timing-safe function https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b