### PR TITLE
feat: support multi match rules by passing options in Array type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+.history
+.vscode

--- a/github-webhook-handler.d.ts
+++ b/github-webhook-handler.d.ts
@@ -13,6 +13,6 @@ interface handler extends EventEmitter {
     (req: IncomingMessage, res: ServerResponse, callback: (err: Error) => void): void;
 }
 
-declare function createHandler(options: CreateHandlerOptions): handler;
+declare function createHandler(options: CreateHandlerOptions|CreateHandlerOptions[]): handler;
 
 export = createHandler;

--- a/github-webhook-handler.js
+++ b/github-webhook-handler.js
@@ -4,23 +4,38 @@ const EventEmitter = require('events').EventEmitter
     , bl           = require('bl')
     , bufferEq     = require('buffer-equal-constant-time')
 
-function create (options) {
+function findHandler(url, arr) {
+  if(!Array.isArray(arr)) return arr
+  var ret = arr[0]
+  for (var i = 0; i < arr.length; i++) {
+    if (url.split('?').shift() === arr[i].path)
+      ret = arr[i]
+  }
+  return ret
+}
+
+function checkType(options) {
   if (typeof options != 'object')
-    throw new TypeError('must provide an options object')
+      throw new TypeError('must provide an options object')
 
-  if (typeof options.path != 'string')
+  if (typeof options.path !== 'string')
     throw new TypeError('must provide a \'path\' option')
-
-  if (typeof options.secret != 'string')
+  
+  if (typeof options.secret !== 'string')
     throw new TypeError('must provide a \'secret\' option')
+}
 
-  var events
+function create (initOptions) {
 
-  if (typeof options.events == 'string' && options.events != '*')
-    events = [ options.events ]
-
-  else if (Array.isArray(options.events) && options.events.indexOf('*') == -1)
-    events = options.events
+  var options
+  //validate type of options
+  if (Array.isArray(initOptions)) {
+    initOptions.forEach(function(item){
+      checkType(item)
+    })
+  } else {
+    checkType(initOptions)
+  }
 
   // make it an EventEmitter, sort of
   handler.__proto__ = EventEmitter.prototype
@@ -41,6 +56,16 @@ function create (options) {
   }
 
   function handler (req, res, callback) {
+    var events
+
+    options = findHandler(req.url, initOptions)
+
+    if (typeof options.events == 'string' && options.events != '*')
+      events = [ options.events ]
+  
+    else if (Array.isArray(options.events) && options.events.indexOf('*') == -1)
+      events = options.events
+      
     if (req.url.split('?').shift() !== options.path || req.method !== 'POST')
       return callback()
 
@@ -96,6 +121,7 @@ function create (options) {
         , protocol: req.protocol
         , host    : req.headers['host']
         , url     : req.url
+        , path    : options.path
       }
 
       handler.emit(event, emitData)


### PR DESCRIPTION
This is the pull request for [this](https://github.com/rvagg/github-webhook-handler/issues/40#issuecomment-508611697)

Support multi match rules. for examples:
``` js
var createHandler = require("github-webhook-handler");
var handler = createHandler([{ path: "/pushCode", secret: "study" },{path:"/pushCodeInterview", secret: "study"}]);

http
    .createServer(function (req, res) {
        console.log(req.path)
        handler(req, res, function (err) {
            res.statusCode = 404;
            res.end("no such location");
        });
    })
    .listen(7777);

handler.on("error", function (err) {
    console.error("Error:", err.message);
});

// listening push event
handler.on("push", function (event) {
    console.log(
        "Received a push event for %s to %s",
        event.payload.repository.name,
        event.payload.ref
    );
    if (event.payload.ref == "refs/heads/master") {
        switch(event.path){
            case '/pushCode':
                init()
                break;
            case '/pushCodeInterview':
                handlerInterview()
                break;
            default:
                break;
        }
    }
});
```

I passed all of the previous test cases and added several use cases in array type, as well as typescript definition files. 

I hope I can reply as soon as possible because I am eager to use the new version of the tool.