### PR TITLE
feat: support multi match rules by passing options in Array type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.history
+.vscode

--- a/github-webhook-handler.d.ts
+++ b/github-webhook-handler.d.ts
@@ -13,6 +13,6 @@ interface handler extends EventEmitter {
     (req: IncomingMessage, res: ServerResponse, callback: (err: Error) => void): void;
 }
 
-declare function createHandler(options: CreateHandlerOptions): handler;
+declare function createHandler(options: CreateHandlerOptions|CreateHandlerOptions[]): handler;
 
 export = createHandler;


### PR DESCRIPTION
> This is the pull request for [this](https://github.com/rvagg/github-webhook-handler/issues/40#issuecomment-508611697)
> 
> Support multi match rules. for examples:
> 
> ```js
> var createHandler = require("github-webhook-handler");
> var handler = createHandler([{ path: "/pushCode", secret: "study" },{path:"/pushCodeInterview", secret: "study"}]);
> 
> http
>     .createServer(function (req, res) {
>         console.log(req.path)
>         handler(req, res, function (err) {
>             res.statusCode = 404;
>             res.end("no such location");
>         });
>     })
>     .listen(7777);
> 
> handler.on("error", function (err) {
>     console.error("Error:", err.message);
> });
> 
> // listening push event
> handler.on("push", function (event) {
>     console.log(
>         "Received a push event for %s to %s",
>         event.payload.repository.name,
>         event.payload.ref
>     );
>     if (event.payload.ref == "refs/heads/master") {
>         switch(event.path){
>             case '/pushCode':
>                 init()
>                 break;
>             case '/pushCodeInterview':
>                 handlerInterview()
>                 break;
>             default:
>                 break;
>         }
>     }
> });
> ```
> 
> I passed all of the previous test cases and added several use cases in array type, as well as typescript definition files.
> 
> I hope I can reply as soon as possible because I am eager to use the new version of the tool.

