### PR TITLE
fix(types): export interfaces

### DIFF
--- a/github-webhook-handler.d.ts
+++ b/github-webhook-handler.d.ts
@@ -3,16 +3,16 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { EventEmitter } from "events";
 
-interface CreateHandlerOptions {
+export interface CreateHandlerOptions {
     path: string;
     secret: string;
     events?: string | string[];
 }
 
-interface handler extends EventEmitter {
+export interface handler extends EventEmitter {
     (req: IncomingMessage, res: ServerResponse, callback: (err: Error) => void): void;
 }
 
 declare function createHandler(options: CreateHandlerOptions|CreateHandlerOptions[]): handler;
 
-export = createHandler;
+export default createHandler;


### PR DESCRIPTION
I am converting a project to TS and was getting the error 

```
error TS9006: Declaration emit for this file requires using private name 'handler' from module '"C:/Users/dopry/src/dopry/pecan/node_modules/github-webhook-handler/github-webhook-handler"'. An explicit type annotation may unblock declaration emit.
```